### PR TITLE
Run tests during `topkg distrib`

### DIFF
--- a/src/topkg_jbuilder.ml
+++ b/src/topkg_jbuilder.ml
@@ -66,9 +66,10 @@ let is_doc files =
   List.mem "doc/api.docdir/index.html" ~set:files
 
 let build =
-  let run_jbuilder _conf os args =
+  let run_jbuilder conf os args =
       let jbuilder = Conf.tool "jbuilder" os in
-      OS.Cmd.run @@ Cmd.(jbuilder %% args % "--root" % ".")
+      let dev_opt = Cmd.(on (Conf.build_context conf = `Dev) (v "--dev")) in
+      OS.Cmd.run @@ Cmd.(jbuilder %% args % "--root" % "." %% dev_opt)
   in
   Pkg.build ()
     ~cmd:(fun conf os files ->


### PR DESCRIPTION
Runs `jbuilder runtest` from the post build phase with `-j <CPUS>`.
This is useful to ensure that tests are passing while building the release tarball.

Commit `ac42e80`: When calling `topkg build` this also enables `--dev` (but you can still run `topkg distrib` as usual, it won't use `--dev`). I found this useful for myself, but not sure whether it should be the default in `topkg-jbuilder`, I could drop it if not, what do you think?