### PR TITLE
use -j1 when running the tests

### DIFF
--- a/src/topkg_jbuilder.ml
+++ b/src/topkg_jbuilder.ml
@@ -86,7 +86,7 @@ let build =
         run_jbuilder conf os Cmd.(empty % "build"))
     ~post:(fun conf ->
         if Conf.build_tests conf then
-          run_jbuilder conf `Host_os Cmd.(empty % "runtest")
+          run_jbuilder conf `Host_os Cmd.(empty % "runtest" % "-j" % "1")
         else Ok ()
     )
     ~clean:(fun os ~build_dir ->


### PR DESCRIPTION
I am not sure what is the best approach here, but sometime you want to be sure that your tests are not run in parallel. Do we want this to be passed as an option to `describe` instead?

Just opening that PR to start the discussion. I don't really care if it is the default or not, as long as I have a way to not run the tests in parallel.